### PR TITLE
Specify the correct secret to use in config

### DIFF
--- a/OAuthWebSample/README.md
+++ b/OAuthWebSample/README.md
@@ -14,7 +14,7 @@ To learn more about OAuth in Visual Studio Team Services, see [Authorize access 
 3. Open the solution (VstsOAuthSample.sln) in Visual Studio 2015 or later
 4. Update the following settings in web.config to match the values in the app you just registered:
   *  App ID
-  *  App Secret
+  *  App Secret (use the "Client Secret" shown on the VSTS Application Settings page, not the App Secret)
   *  Scope (space separated)
   *  Callback URL
 5. Build the solution (this will trigger a NuGet package restore, which will pull in all dependencies of the project)


### PR DESCRIPTION
The current VSTS application settings page is very confusing and now has an "App Secret" and a "Client Secret".  This demo only works if you use the Client Secret.  If you use the "App Secret" you will get a 400 Bad Request when requesting the access token.

Probably the best thing to do would be rename the web config setting to Client Secret to make this abundantly clearer.