### PR TITLE
Use ClientSecret instead of AppSecret when requesting token

### DIFF
--- a/OAuthWebSample/OAuthWebSample/Controllers/OAuthController.cs
+++ b/OAuthWebSample/OAuthWebSample/Controllers/OAuthController.cs
@@ -128,7 +128,7 @@ namespace OAuthSample.Controllers
         public string GenerateRequestPostData(string code)
         {
             return string.Format("client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion={0}&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion={1}&redirect_uri={2}",
-                HttpUtility.UrlEncode(ConfigurationManager.AppSettings["AppSecret"]),
+                HttpUtility.UrlEncode(ConfigurationManager.AppSettings["ClientSecret"]),
                 HttpUtility.UrlEncode(code),
                 ConfigurationManager.AppSettings["CallbackUrl"]
                 );
@@ -137,7 +137,7 @@ namespace OAuthSample.Controllers
         public string GenerateRefreshPostData(string refreshToken)
         {
             return string.Format("client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion={0}&grant_type=refresh_token&assertion={1}&redirect_uri={2}",
-                HttpUtility.UrlEncode(ConfigurationManager.AppSettings["AppSecret"]),
+                HttpUtility.UrlEncode(ConfigurationManager.AppSettings["ClientSecret"]),
                 HttpUtility.UrlEncode(refreshToken),
                 ConfigurationManager.AppSettings["CallbackUrl"]
                 );

--- a/OAuthWebSample/OAuthWebSample/Web.config
+++ b/OAuthWebSample/OAuthWebSample/Web.config
@@ -13,6 +13,7 @@
     <!-- App Settings for OAuth-->
     <add key="AppId" value=""/>
     <add key="AppSecret" value=""/>
+    <add key="ClientSecret" value=""/>
     <add key="Scope" value=""/>
     <add key="AuthUrl" value="https://app.vssps.visualstudio.com/oauth2/authorize"/>
     <add key="TokenUrl" value="https://app.vssps.visualstudio.com/oauth2/token"/>


### PR DESCRIPTION
## Summary
Using `AppSecret` when requesting token doesn't work, it returns 400 bad request error - use `ClientSecret` instead.

Related issue: https://github.com/Microsoft/vsts-auth-samples/issues/8